### PR TITLE
Issue #1

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,121 @@
+# 🏃‍♀️ Continuous Integration and Delivery
+# =======================================
+#
+# This is a GitHub Action workflow that provides Continuous Integration (CI)
+# and Continuous Delivery (CD) of the PDS_ Deep Archive software. Currently
+# it generates installable packages and publishes documentation, but in the
+# future it could also run unit+integration+functional tests, save other
+# artifacts, and so forth.
+#
+# Access Tokens
+# -------------
+#
+# The following tokens must be installed in the project's GitHub repository
+# in ordr for this workflow to function:
+#
+# ``github_personal_access_token``
+#     A personal access token of a user with collaborator or better access to
+#     the project repository. You can generate this by visiting GitHub →
+#     Settings → Developer settings → Personal access tokens → Generate new
+#     token. Give the token scope on ``repo``.
+# ``pypi_upload_token``
+#     An API token for the Python Package Index. You can make one by visiting
+#     pypi.org and choosing Account Settings → Add API Token. It's best to
+#     narrow the scope of the token to just one PyPI project, but that's only
+#     available for projects already hosted on PyPI.
+#  ``test_pypi_upload_token``
+#     The same, but for test.pypi.org.
+#
+#
+# .. _PDS: https://pds.nasa.gov/
+
+
+---
+
+name: 📦 Continuous Integration & Delivery
+
+
+# Driving Event
+# -------------
+#
+# What event starts this workflow: a push. We could refine this to a specific
+# branch, except that we detect if we're pushing to a release tag in the flow
+# and can publish to the official PyPI in addition to the test PyPI. (We
+# always publish to the test PyPI.)
+
+on: push
+
+
+# What to Do
+# ----------
+#
+# Once we get the event, what shall we do? Two things:
+# • Generate and publish documentation to the web
+# • Make an installable package
+#   • Always auto-publish to test.pypi.org
+#   • For tagged releases, auto-publish to the official pypi.org
+
+jobs:
+    documentation:
+        name: 📄 Documentation
+        runs-on: ubuntu-latest
+        steps:
+            -
+                name: ⚙️ Checking out repository
+                uses: actions/checkout@v2
+            -
+                name: 🐍 Installing Python
+                uses: actions/setup-python@v1
+                with:
+                    python-version: '3.x'
+                    architecture: 'x64'
+            -
+                name: 🖋 Writing documentation
+                run: |
+                    python3 bootstrap.py
+                    bin/buildout
+                    bin/docbuilder
+            -
+                name: 📒 Publishing to GitHub Pages
+                if: success()
+                uses: crazy-max/ghaction-github-pages@master
+                env:
+                    GITHUB_PAT: ${{secrets.github_personal_access_token}}
+                with:
+                    target_branch: gh-pages
+                    build_dir: build/docs/html
+    packaging:
+        name: 📦 Packaging
+        runs-on: ubuntu-latest
+        steps:
+            -
+                name: ⚙️ Checking out repository
+                uses: actions/checkout@v2
+            -
+                name: 🐍 Installing Python
+                uses: actions/setup-python@v1
+                with:
+                    python-version: '3.x'
+                    architecture: 'x64'
+            -
+                name: 💽 Building distribution
+                run: |
+                    rm -rf dist
+                    python3 bootstrap.py
+                    bin/buildout
+                    bin/buildout setup . sdist
+            # Put in unit+functional+integration testing here
+            -
+                name: 📇 Publishing to Test PyPI
+                uses: pypa/gh-action-pypi-publish@v1.0.0a0
+                with:
+                    password: ${{secrets.test_pypi_upload_token}}
+                    repository_url: https://test.pypi.org/legacy/
+            -
+                name: 🗂 Publishing to PyPI
+                uses: pypa/gh-action-pypi-publish@v1.0.0a0
+                if: startsWith(github.event.ref, 'refs/tags')
+                with:
+                    password: $${secrets.pypi_upload_token}}
+
+...

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -69,6 +69,7 @@ jobs:
                 with:
                     python-version: '3.x'
                     architecture: 'x64'
+            -
                 name: 🚼 Adding dependencies
                 run: |
                     sudo apt-get install -y libxml2-dev libxslt1-dev

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -69,6 +69,9 @@ jobs:
                 with:
                     python-version: '3.x'
                     architecture: 'x64'
+                name: 🚼 Adding dependencies
+                run: |
+                    sudo apt-get install -y libxml2-dev libxslt1-dev
             -
                 name: 🖋 Writing documentation
                 run: |
@@ -97,6 +100,10 @@ jobs:
                 with:
                     python-version: '3.x'
                     architecture: 'x64'
+            -
+                name: 🚼 Adding dependencies
+                run: |
+                    sudo apt-get install -y libxml2-dev libxslt1-dev
             -
                 name: 💽 Building distribution
                 run: |

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-*********
-PDS Deep Archive Utilities
-*********
+****************************
+ PDS Deep Archive Utilities
+****************************
 
 Software for the Planetary Data System (PDS_) to generate Archive Information
 Package (AIP) and Submission Information Package (SIP) products, based upon Open
@@ -157,6 +157,7 @@ LICENSE.txt file for details.
 .. _OAIS: https://www2.archivists.org/groups/standards-committee/open-archival-information-system-oais
 .. _PDS: https://pds.nasa.gov/
 .. _virtualenv: https://docs.python.org/3/library/venv.html
+.. _lxml: https://lxml.de/
 
 
 .. Copyright © 2019–2020 California Institute of Technology ("Caltech").

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,6 +8,7 @@ parts =
     python
     omelette
     test
+    docbuilder
 
 
 [python]
@@ -27,4 +28,14 @@ eggs = ${buildout:package-name}[test]
 defaults = ['--auto-color', '--auto-progress', '--verbose']
 
 
+[docbuilder]
+recipe = collective.recipe.sphinxbuilder
+source = ${buildout:directory}/docs/source
+build = ${buildout:directory}/build/docs
+interpreter = ${buildout:bin-directory}/python
+outputs = html
+
+
 [versions]
+collective.recipe.sphinxbuilder = 1.1
+Sphinx = 1.8.5

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,80 @@
+# Sphinx Configuration 🐈
+# =======================
+#
+# See the full Sphinx config docs at::
+#     https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+
+# Project Metadata
+# ----------------
+#
+# There's both ``version`` and ``release`` here per Sphinx quickstart; is
+# there a way to get parity with ``setup.py`` though? 🤔
+
+project            = 'PDS Deep Archive'
+author             = 'NASA PDS Incubator Project'
+copyright          = '2020, NASA PDS Incubator Project'
+version            = '1.0'
+release            = '1.0.0'
+language           = 'en'
+
+
+# Sphinx Setup
+# ------------
+#
+# Stuff that controls Sphinx.
+#
+#
+# Settings
+# ~~~~~~~~
+#
+# Note that some of these settings are for certain extensions, see below.
+
+exclude_patterns   = []
+html_static_path   = ['_static']
+html_theme         = 'alabaster'
+html_theme_options = {}
+master_doc         = 'index'
+pygments_style     = 'sphinx'
+source_suffix      = '.rst'
+templates_path     = ['_templates']
+todo_include_todos = True
+
+
+# Extensions
+# ~~~~~~~~~~
+#
+# These are add-ons, most of which we don't use (for now).
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.todo',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
+    'sphinx.ext.autosummary',
+]
+
+
+# Alabaster Theme
+# ~~~~~~~~~~~~~~~
+#
+# The "alabaster" theme requires these settings
+
+html_sidebars = {
+    '**': [
+        'relations.html',  # needs 'show_related': True theme option to display
+        'searchbox.html',
+    ]
+}
+
+
+# Other Options
+# ~~~~~~~~~~~~~
+#
+# Not used here, but we could include in the future:
+#
+# • HTMLHelp formatting
+# • LaTeX output
+# • Man page generation
+# • TeXinfo output

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -1,0 +1,5 @@
+👩‍💻 Development
+=================
+
+Developer details forthcoming.
+

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -1,5 +1,35 @@
 👩‍💻 Development
 =================
 
-Developer details forthcoming.
+The quickest way to get started developing this package is to clone it and
+build it out::
 
+    git clone https://github.com/NASA-PDS-Incubator/pds-deep-archive.git
+    cd pds-deep-archive
+    python3 bootstrap.py
+    bin/buildout
+
+At this point, you'll have the ``sipgen`` program ready to run as
+``bin/sipgen`` that's set up to use source Python code under ``src``. Changes
+you make to the code are reflected in ``bin/sipgen`` immediately.
+
+The documentation is in ``docs/source``, formatted as reStructuredText_ and
+structured with Sphinx_.  To build the HTML from the documentation, run
+``bin/docbuilder``. It will write HTML output to ``build/docs/html``.
+
+You can also build local distributions or run any ``setuptools`` command via
+the buildout refrain::
+
+    bin/buildout setup . --help-commands
+
+Commits back to GitHub will trigger workflows in GitHub Actions_ that
+re-publish the project website_ as well as send artifacts to testing_ Python
+Package Index.  (The official Python Package Index gets updated only with
+official release tags.)
+
+
+.. _reStructuredText: https://docutils.sourceforge.io/rst.html
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
+.. _testing: https://test.pypi.org/
+.. _Actions: https://github.com/features/actions
+.. _website: https://nasa-pds-incubator.github.io/pds-deep-archive/

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -27,6 +27,11 @@ re-publish the project website_ as well as send artifacts to testing_ Python
 Package Index.  (The official Python Package Index gets updated only with
 official release tags.)
 
+..  note::
+
+    The Python Package Index requires artifacts be uniquely named, so *always*
+    update the ``setup.py`` version info!
+
 
 .. _reStructuredText: https://docutils.sourceforge.io/rst.html
 .. _Sphinx: https://www.sphinx-doc.org/en/master/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,31 @@
+🪐 PDS Deep Archive
+===================
+
+The PDS Deep Archive is a Python_ based package providing utilities for
+handling *deep* archives. It includes software for Archive Information Package
+(AIP) and Submission Information Package (SIP) products, based on Open
+Archival Information System (OAIS_) standards.
+
+Currently, this package provides an executable program, ``sipgen``, that
+creates Submission Information Packages (SIPs) from PDS bundles.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   installation/index
+   usage/index
+   development/index
+
+
+.. Perhaps we will use this in the future:
+.. Indexes and Tables
+.. ==================
+
+.. • :ref:`genindex`
+.. • :ref:`modindex`
+.. • :ref:`search`
+
+.. _OAIS: https://www2.archivists.org/groups/standards-committee/open-archival-information-system-oais
+.. _Python: https://www.python.org/

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -1,0 +1,63 @@
+📦 Installation
+===============
+
+This section describes how to install the PDS Deep Archive.
+
+
+Requirements
+------------
+
+Prior to installing this software, ensure your system meets the following
+requirements:
+
+•  Python_ 3. This software requires Python 3; it will work with 3.6, 3.7, or
+   3.8.  Python 2 will absolutely *not* work, and indeed Python 2 came to its
+   end of life on the first of January, 2020.  Run ``python3 --version`` to
+   check.
+•  ``libxml2`` version 2.9.2; later 2.9 versions are fine.  Run ``xml2-config
+   --version`` to find out.
+•  ``libxslt`` version 1.1.28; later 1.1 versions are OK too.  Run
+   ``xslt-config`` to see.
+
+Consult your operating system instructions or system administrator to install
+the required packages.
+
+
+Doing the Installation
+----------------------
+
+The easiest way to install this software is to use Pip_, the Python Package
+Installer. If you have Python on your system, you probably already have Pip;
+you can run ``pip3 --help`` to check.
+
+It's best install the PDS Deep Archive into a `virtual environment`_ so it
+won't interfere with—or be interfered by—other packages.  To do so::
+
+    mkdir -p $HOME/.virtualenvs
+    python3 -m venv $HOME/.virtualenvs/pds-deep-archive
+    source $HOME/.virtualenvs/pds-deep-archive/bin/activate
+    pip3 install pds.deeparchive
+
+It's also possible to use ``easy_install`` if you prefer, or to install it
+via a Buildout_, or (if you must) into the system Python.
+
+You can then run ``sipgen --help`` to get a usage message and ensure it's
+properly installed.
+
+
+..  note::
+
+    The above commands will install last approved release from the Python
+    Package Index ("Cheeseshop_"). The latest, cutting edge release is posted
+    at the Test Package Index, but these releases may not be fully confirmed
+    to be operational. If you like taking risks, add
+    ``--index-url https://test.pypi.org/simple`` to the ``pip3 install``
+    command.
+
+
+.. References:
+.. _Pip: https://pip.pypa.io/en/stable/
+.. _Python: https://www.python.org/
+.. _`virtual environment`: https://docs.python.org/3/library/venv.html
+.. _Buildout: http://www.buildout.org/
+.. _Cheeseshop: https://pypi.org/

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -1,0 +1,64 @@
+🏃‍♀️ Usage
+=========
+
+This package provides one executable, ``sipgen``, that generates Submission
+Information Package (SIP) from PDS bundles.
+
+Running ``sipgen --help`` will give a summary of the command-line invocation,
+its required arguments, and any options that refine the behavior.  For
+example, to create a SIP from the LADEE 1101 bundle in
+``test/data/ladee_test/ladee_mission_bundle/LADEE_Bundle_1101.xml``, run::
+
+    sipgen --s PDS_ATM --offline --bundle-base-url https://atmos.nmsu.edu/PDS/data/PDS4/LADEE/ test/data/ladee_test/ladee_mission_bundle/LADEE_Bundle_1101.xml
+
+The program will print::
+
+    ⚙︎ ``sipgen`` — Submission Information Package (SIP) Generator, version 0.0.0
+    🎉 Success! From test/data/ladee_test/ladee_mission_bundle/LADEE_Bundle_1101.xml, generated these output files:
+    • Manifest: ladee_mission_bundle_sip_v1.0.tab
+    • Label: ladee_mission_bundle_sip_v1.0.xml
+
+And two new files will appear in the current directory:
+
+•  ``ladee_mission_bundle_sip_v1.0.tab``, the created SIP manifest as a
+   tab-separated values file.
+•  ``ladee_mission_bundle_sip_v1.0.xml``, an PDS label for the SIP file.
+
+For reference, the full "usage" message from ``sipgen`` follows::
+
+    usage: sipgen [-h] [-a {MD5,SHA-1,SHA-256}] -s
+                  {PDS_ATM,PDS_ENG,PDS_GEO,PDS_IMG,PDS_JPL,PDS_NAI,PDS_PPI,PDS_PSI,PDS_RNG,PDS_SBN}
+                  [-u URL] [-k] [-n] [-b BUNDLE_BASE_URL] [-v]
+                  [-i PDS4_INFORMATION_MODEL_VERSION]
+                  IN-BUNDLE.XML
+
+    Generate Submission Information Packages (SIPs) from bundles. This program
+    takes a bundle XML file as input and produces two output files: ① A Submission
+    Information Package (SIP) manifest file; and ② A PDS XML label of that file.
+    The files are created in the current working directory when this program is
+    run. The names of the files are based on the logical identifier found in the
+    bundle file, and any existing files are overwritten. The names of the
+    generated files are printed upon successful completion.
+
+    positional arguments:
+      IN-BUNDLE.XML         Bundle XML file to read
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -a {MD5,SHA-1,SHA-256}, --algorithm {MD5,SHA-1,SHA-256}
+                            File hash (checksum) algorithm; default MD5
+      -s {PDS_ATM,PDS_ENG,PDS_GEO,PDS_IMG,PDS_JPL,PDS_NAI,PDS_PPI,PDS_PSI,PDS_RNG,PDS_SBN}, --site {PDS_ATM,PDS_ENG,PDS_GEO,PDS_IMG,PDS_JPL,PDS_NAI,PDS_PPI,PDS_PSI,PDS_RNG,PDS_SBN}
+                            Provider site ID for the manifest's label; default
+                            None
+      -u URL, --url URL     URL to the registry service; default https://pds-dev-
+                            el7.jpl.nasa.gov/services/registry/pds
+      -k, --insecure        Ignore SSL/TLS security issues; default False
+      -n, --offline         Run offline, scanning bundle directory for matching
+                            files instead of querying registry service
+      -b BUNDLE_BASE_URL, --bundle-base-url BUNDLE_BASE_URL
+                            Base URL prepended to URLs in the generated manifest
+                            for local files in "offline" mode
+      -v, --verbose         Verbose logging; defaults False
+      -i PDS4_INFORMATION_MODEL_VERSION, --pds4-information-model-version PDS4_INFORMATION_MODEL_VERSION
+                            Specify PDS4 Information Model version to generate
+                            SIP. Must be 1.13.0.0+; default 1.13.0.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ _requirements = [
 
 setup(
     name='pds.deeparchive',
-    version='0.0.0',
+    version='0.0.1',
     description='SIP Generator',
     long_description=readme + '\n\n' + changes,
     keywords='PDS CCSDS OAIS AIP SIP metadata submission archive package',

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     author_email='sean.kelly@jpl.nasa.gov',
     url='https://github.com/NASA-PDS-Incubator/pds-deep-archive/',
     entry_points={
-        'console_scripts': ['sipgen=pds.deeparchive.sip:main']
+        'console_scripts': ['sipgen=pds.aipgen.sip:main']
     },
     namespace_packages=['pds'],
     packages=find_packages('src', exclude=['docs', 'tests', 'bootstrap', 'ez_setup']),
@@ -75,7 +75,7 @@ setup(
     zip_safe=True,
     install_requires=_requirements,
     extras_require={'test': []},
-    license='Proprietary',
+    license='ALv2',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',


### PR DESCRIPTION
This pull request addresses issue #1 by providing:

-  An initial set of reStructuredText style documentation
-  Sphinx-style documentation structure and generator
-  CI/CD workflow via GitHub Actions that:
    - Publishes the documentation to the [project website](https://nasa-pds-incubator.github.io/pds-deep-archive/index.html)
    - Publishes every build from every push to the [Test PyPI](https://test.pypi.org//)
    - Publishes release tag pushed to the [main PyPI](https://pypi.org/)

It also fixes a couple issues with the package metadata:

- Installed packages were trying to import an unknown path `pds.deeparchive` and wouldn't run.
- The setup metadata still said "Proprietary" license instead of ALv2.

Resolves #1 