### PR TITLE
Update SIP Generator to ensure only primary lidvids are included in manifest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ _requirements = [
     'setuptools',  # All modern setup.py's should require setuptools
     'pysolr',      # In online mode, we look up products using Solr
     'lxml',        # Needed for generating XML labels (since ElementTree can't add XML PIs above the root elem!)
+    'packaging',   # To parse and compare version IDs
 ]
 
 

--- a/src/pds/aipgen/main.py
+++ b/src/pds/aipgen/main.py
@@ -104,7 +104,8 @@ def main():
             args.site,
             args.offline,
             args.bundle_base_url,
-            chksumStream
+            chksumStream,
+            args.include_all_collections
         )
     _logger.info("👋 That's it! Thanks for making an AIP and SIP with us today. Bye!")
     sys.exit(0)

--- a/src/pds/aipgen/tests/test_functional.py
+++ b/src/pds/aipgen/tests/test_functional.py
@@ -57,6 +57,7 @@ class SIPFunctionalTestCase(unittest.TestCase):
             site='PDS_ATM',
             offline=True,
             baseURL='https://atmos.nmsu.edu/PDS/data/PDS4/LADEE/',
+            allCollections=True,
             aipFile=None
         )
         self.assertTrue(filecmp.cmp(manifest, self.valid), "SIP manifest doesn't match the valid version")


### PR DESCRIPTION
### Summary

-   Resolve #39: SIP contains just one product for Insight Spice example
    -   We match the lidvid against all primaries found
    -   Take advantage of a new LogicalReference class for lid+lidvid manipulations
        -   This probably already exists in Java land?
    -   Look for either lid_reference or lidvid_reference in bundle XML
-   Add a way to compare, hash, and manipulate lidvids with optional vids: class LogicalReference
    -   Representation, stringification
    -   Hashing, equality, comparisons
        -   Compare version IDs smartly (i.e., 2.9 < 2.10)
    -   Matching based on partial lid or full lidvid
    -   Battery of unit tests
-   Begin support for #24 with command-line handling and flag passing
    -   But default it to True until we have time to actually put it in
        -   Include prominent warning that we're doing that
-   Remove redundant database connection use and commit

### Test Data

```console
$ bin/test
Running tests at level 1
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
    2/14 (14.3%) test_logging_arguments (pds.aipgen.tests.test_utils.ArgumentTestCase)usage: 
                                                                                                          
  Ran 14 tests with 0 failures, 0 errors, 0 skipped in 0.048 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
```

**Related Issues**

- Resolves #39 
- Includes initial framework for #24 
