### PR TITLE
Resolve #44 - `manifest_url` for SIP labels

### DIFF
--- a/src/pds/aipgen/constants.py
+++ b/src/pds/aipgen/constants.py
@@ -62,3 +62,6 @@ HASH_ALGORITHMS = {
     'SHA-1':   'sha1',
     'SHA-256': 'sha256',
 }
+
+# The "well-defined" location for SIP manifests
+SIP_MANIFEST_URL = 'https://pds-gamma.jpl.nasa.gov/data/pds4/manifests/'

--- a/src/pds/aipgen/constants.py
+++ b/src/pds/aipgen/constants.py
@@ -64,4 +64,4 @@ HASH_ALGORITHMS = {
 }
 
 # The "well-defined" location for SIP manifests
-SIP_MANIFEST_URL = 'https://pds-gamma.jpl.nasa.gov/data/pds4/manifests/'
+SIP_MANIFEST_URL = 'https://pds.nasa.gov/data/pds4/manifests/'

--- a/src/pds/aipgen/sip.py
+++ b/src/pds/aipgen/sip.py
@@ -33,7 +33,7 @@
 
 from .constants import (
     INFORMATION_MODEL_VERSION, PDS_NS_URI, XML_SCHEMA_INSTANCE_NS_URI, XML_MODEL_PI,
-    PDS_SCHEMA_URL, AIP_PRODUCT_URI_PREFIX, PDS_LABEL_FILENAME_EXTENSION, HASH_ALGORITHMS
+    PDS_SCHEMA_URL, AIP_PRODUCT_URI_PREFIX, PDS_LABEL_FILENAME_EXTENSION, HASH_ALGORITHMS, SIP_MANIFEST_URL
 )
 from .utils import (
     getPrimariesAndOtherInfo, getMD5, getLogicalIdentifierAndFileInventory, parseXML, getDigest, addLoggingArguments
@@ -353,8 +353,8 @@ def _writeLabel(logicalID, versionID, title, digest, size, numEntries, hashName,
     deep.append(etree.Comment('MD5 digest checksum for the manifest file'))
     etree.SubElement(deep, prefix + 'manifest_checksum').text = digest
     etree.SubElement(deep, prefix + 'checksum_type').text = 'MD5'
-    etree.SubElement(deep, prefix + 'manifest_url').text = 'file:' + os.path.abspath(manifestFile)
-    etree.SubElement(deep, prefix + 'aip_lidvid').text = AIP_PRODUCT_URI_PREFIX + logicalID.split(':')[-1]+ '_v' + versionID + '::1.0'
+    etree.SubElement(deep, prefix + 'manifest_url').text = SIP_MANIFEST_URL
+    etree.SubElement(deep, prefix + 'aip_lidvid').text = AIP_PRODUCT_URI_PREFIX + logicalID.split(':')[-1] + '_v' + versionID + '::1.0'
 
     aipMD5 = getMD5(aipFile) if aipFile else '00000000000000000000000000000000'
     etree.SubElement(deep, prefix + 'aip_label_checksum').text = aipMD5

--- a/src/pds/aipgen/tests/test_functional.py
+++ b/src/pds/aipgen/tests/test_functional.py
@@ -79,7 +79,7 @@ class SIPFunctionalTestCase(unittest.TestCase):
         )
         matches = etree.parse(label).getroot().findall(self._urlXPath)
         self.assertEqual(1, len(matches))
-        self.assertEqual('https://pds-gamma.jpl.nasa.gov/data/pds4/manifests/', matches[0].text)
+        self.assertEqual('https://pds.nasa.gov/data/pds4/manifests/', matches[0].text)
     def tearDown(self):
         self.input.close()
         os.chdir(self.cwd)


### PR DESCRIPTION
### Summary

-   Resolve #44 …
    -   Test case to expose the issue (`http` versus `file` URL)
    -   New constant for SIP manifest locations
    -   Slight PEP-8 cosmetic fix (spaces around `+`)

### Test Data and/or Report

```console
$ bin/test
Running tests at level 1
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
    3/15 (20.0%) test_logging_arguments (pds.aipgen.tests.test_utils.ArgumentTestCase)usage: 
                                                                                                          
  Ran 15 tests with 0 failures, 0 errors, 0 skipped in 0.046 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
```

### Related Issues

- (Future issue number) For when "they" realize that `manifest_url` maybe isn't the right idea 🤷‍♀️